### PR TITLE
Move from CCC to Fabric Commands API v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-	id 'fabric-loom' version '0.5-SNAPSHOT'
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 	id "com.modrinth.minotaur" version "1.1.0"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 }
@@ -31,7 +31,10 @@ repositories {
 	maven {
         name = 'CottonMC'
 	    url = 'http://server.bbkr.space:8081/artifactory/libs-release'
-	}    
+	}
+    maven {
+        url "https://jitpack.io"
+    }
 }
 
 sourceCompatibility = 1.8
@@ -46,7 +49,7 @@ ext.projectVersion = "1.1.3"
 version = "${Versions['minecraft_version']}-fabric${Versions['fabric_versiononly']}-${project.projectVersion}"
 
 minecraft {
-    refmapName = "AntiGhost-refmap.json";
+    refmapName = "AntiGhost-refmap.json"
 }
 
 processResources {
@@ -66,8 +69,6 @@ dependencies {
     mappings   "net.fabricmc:yarn:${Versions['yarn_mappings']}:v2"
     modImplementation "net.fabricmc:fabric-loader:${Versions['loader_version']}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${Versions['fabric_version']}"
-    modImplementation "io.github.cottonmc:cotton-client-commands:${Versions['ccc_version']}"
-    include    "io.github.cottonmc:cotton-client-commands:${Versions['ccc_version']}"
     modImplementation "de.guntram.mcmod:crowdin-translate:1.2"
     include "de.guntram.mcmod:crowdin-translate:1.2"
 }

--- a/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
+++ b/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
@@ -1,11 +1,8 @@
 package de.guntram.mcmod.antighost;
 
-import com.mojang.brigadier.CommandDispatcher;
 import de.guntram.mcmod.crowdintranslate.CrowdinTranslate;
-import static io.github.cottonmc.clientcommands.ArgumentBuilders.literal;
-import io.github.cottonmc.clientcommands.ClientCommandPlugin;
-import io.github.cottonmc.clientcommands.CottonClientCommandSource;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.command.v1.ClientCommandManager;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
@@ -18,7 +15,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_G;
 
-public class AntiGhost implements ClientModInitializer, ClientCommandPlugin
+public class AntiGhost implements ClientModInitializer
 {
     static final String MODID="antighost";
     static KeyBinding requestBlocks;
@@ -31,16 +28,11 @@ public class AntiGhost implements ClientModInitializer, ClientCommandPlugin
         CrowdinTranslate.downloadTranslations(MODID);
         KeyBindingHelper.registerKeyBinding(requestBlocks);
         ClientTickEvents.END_CLIENT_TICK.register(e->keyPressed());
-    }
-    
-    
-    @Override
-    public void registerCommands(CommandDispatcher<CottonClientCommandSource> cd) {
-        cd.register(
-            literal("ghost").executes(c->{
-                this.execute();
-                return 1;
-            })
+        ClientCommandManager.DISPATCHER.register(
+                ClientCommandManager.literal("ghost").executes(c -> {
+                    this.execute();
+                    return 1;
+                })
         );
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,8 +4,7 @@
     "version": "${version}",
     "environment": "client",
     "entrypoints": {
-        "client": [ "de.guntram.mcmod.antighost.AntiGhost" ],
-        "cotton-client-commands": ["de.guntram.mcmod.antighost.AntiGhost"]
+        "client": [ "de.guntram.mcmod.antighost.AntiGhost" ]
     },
     "custom": {
         "modupdater": {


### PR DESCRIPTION
CCC has been deprecated in favour of Fabric Commands API v1. You'll have to update the Versionfiles manually, after merging gbl/Versionfiles#2. Also added jitpack.io Maven repo as it has up to date Mod Menu version, and updated Fabric Loom version.