### PR TITLE
Capitalize "Requesting resend of blocks around you" and move it to the action bar

### DIFF
--- a/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
+++ b/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
@@ -40,7 +40,7 @@ public class AntiGhost implements ClientModInitializer
         ClientPlayerEntity player = MinecraftClient.getInstance().player;
         if (requestBlocks.wasPressed()) {
             this.execute();
-            player.sendMessage(new TranslatableText("msg.request"), false);
+            player.sendMessage(new TranslatableText("msg.request"), true);
         }
     }
     

--- a/src/main/resources/assets/antighost/lang/cs_cz.json
+++ b/src/main/resources/assets/antighost/lang/cs_cz.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Zobrazit zmizelé bloky",
-    "msg.request": "požadovat opětovné odeslání bloků kolem vás"
+    "msg.request": "Požadovat opětovné odeslání bloků kolem vás"
 }

--- a/src/main/resources/assets/antighost/lang/el_gr.json
+++ b/src/main/resources/assets/antighost/lang/el_gr.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Reveal ghost blocks",
-    "msg.request": "requesting resend of blocks around you"
+    "msg.request": "Requesting resend of blocks around you"
 }

--- a/src/main/resources/assets/antighost/lang/en_us.json
+++ b/src/main/resources/assets/antighost/lang/en_us.json
@@ -1,5 +1,5 @@
 {
 "key.categories.antighost": "AntiGhost",
 "key.antighost.reveal": "Reveal ghost blocks",
-"msg.request": "requesting resend of blocks around you"
+"msg.request": "Requesting resend of blocks around you"
 }

--- a/src/main/resources/assets/antighost/lang/fi_fi.json
+++ b/src/main/resources/assets/antighost/lang/fi_fi.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiHaamu",
     "key.antighost.reveal": "Paljastetaan haamupalikat",
-    "msg.request": "pyydetään, että palikat ympärilläsi lähetetään uudelleen"
+    "msg.request": "Pyydetään, että palikat ympärilläsi lähetetään uudelleen"
 }

--- a/src/main/resources/assets/antighost/lang/fr_fr.json
+++ b/src/main/resources/assets/antighost/lang/fr_fr.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Afficher les blocs fantômes",
-    "msg.request": "demander un renvoi des blocs autour de vous"
+    "msg.request": "Demander un renvoi des blocs autour de vous"
 }

--- a/src/main/resources/assets/antighost/lang/it_it.json
+++ b/src/main/resources/assets/antighost/lang/it_it.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Mostra blocchi fantasma",
-    "msg.request": "richiedendo reinvio dei blocchi intorno a te"
+    "msg.request": "Richiedendo reinvio dei blocchi intorno a te"
 }

--- a/src/main/resources/assets/antighost/lang/ko_kr.json
+++ b/src/main/resources/assets/antighost/lang/ko_kr.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Reveal ghost blocks",
-    "msg.request": "requesting resend of blocks around you"
+    "msg.request": "Requesting resend of blocks around you"
 }

--- a/src/main/resources/assets/antighost/lang/no_no.json
+++ b/src/main/resources/assets/antighost/lang/no_no.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "Antispøke",
     "key.antighost.reveal": "Via spøkeblokker",
-    "msg.request": "requesting resend of blocks around you"
+    "msg.request": "Requesting resend of blocks around you"
 }

--- a/src/main/resources/assets/antighost/lang/pl_pl.json
+++ b/src/main/resources/assets/antighost/lang/pl_pl.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntyNiewidzialneBloki",
     "key.antighost.reveal": "Pokaż niewidzialne bloki",
-    "msg.request": "próba ponownego wysłania bloków wokół ciebie"
+    "msg.request": "Próba ponownego wysłania bloków wokół ciebie"
 }

--- a/src/main/resources/assets/antighost/lang/pt_br.json
+++ b/src/main/resources/assets/antighost/lang/pt_br.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "Sem Fantasma",
     "key.antighost.reveal": "Revelar blocos fantasmas",
-    "msg.request": "solicitando o reenvio de blocos ao seu redor"
+    "msg.request": "Solicitando o reenvio de blocos ao seu redor"
 }

--- a/src/main/resources/assets/antighost/lang/pt_pt.json
+++ b/src/main/resources/assets/antighost/lang/pt_pt.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "Sem Fantasma",
     "key.antighost.reveal": "Revelar blocos fantasmas",
-    "msg.request": "solicitando o reenvio de blocos ao seu redor"
+    "msg.request": "Solicitando o reenvio de blocos ao seu redor"
 }

--- a/src/main/resources/assets/antighost/lang/ro_ro.json
+++ b/src/main/resources/assets/antighost/lang/ro_ro.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Reveal ghost blocks",
-    "msg.request": "requesting resend of blocks around you"
+    "msg.request": "Requesting resend of blocks around you"
 }

--- a/src/main/resources/assets/antighost/lang/sr_sp.json
+++ b/src/main/resources/assets/antighost/lang/sr_sp.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Reveal ghost blocks",
-    "msg.request": "requesting resend of blocks around you"
+    "msg.request": "Requesting resend of blocks around you"
 }

--- a/src/main/resources/assets/antighost/lang/sv_se.json
+++ b/src/main/resources/assets/antighost/lang/sv_se.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiSpöke",
     "key.antighost.reveal": "Visa spök blocks",
-    "msg.request": "begär att block ska skickas om omkring dig"
+    "msg.request": "Begär att block ska skickas om omkring dig"
 }

--- a/src/main/resources/assets/antighost/lang/tr_tr.json
+++ b/src/main/resources/assets/antighost/lang/tr_tr.json
@@ -1,5 +1,5 @@
 {
     "key.categories.antighost": "AntiGhost",
     "key.antighost.reveal": "Hayalet blokları göster",
-    "msg.request": "etrafındaki blokların yeniden gönderilmesi isteniyor"
+    "msg.request": "Etrafındaki blokların yeniden gönderilmesi isteniyor"
 }


### PR DESCRIPTION
Capitalize "Requesting resend of blocks around you" message and move it to the action bar to avoid cluttering chat. In my opinion, the message looks much better in the action bar, and then it doesn't stick around clogging up your chat. I also capitalized any message that didn't start with a capital letter.