### PR TITLE
adds registration for keybinding back through mod bus (resolves #35)

### DIFF
--- a/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
+++ b/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
@@ -26,7 +26,6 @@ public class AntiGhost
     static final String MODID="antighost";
     static final String MODNAME="AntiGhost";
     static final KeyMapping ON_REVEAL = new KeyMapping("key.antighost.reveal", GLFW.GLFW_KEY_G, "key.categories.antighost");
-    static boolean handled = false;
     
     public AntiGhost() {
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();


### PR DESCRIPTION
the docs are a bit unclear but to register the keymapping, it needs to go through the mod event bus instead of just in the mod class itself. this can be directly registered through an instance of the mod bus, or through a separate class annotated with @ModBusSubscriber. I chose the former to reduce scope of changes. The key is then checked through the ClientTickEvent as suggested

ref: https://docs.minecraftforge.net/en/latest/misc/keymappings/
resolves: https://github.com/gbl/AntiGhost/issues/35

one thing to consider is a timeout or locking mechanism for the keybind activation, instead of allowing it to trigger every tick while held. this is not a newly introduced issue however, it exists when using InputEvent.Key as well

also I did not change the version, not sure how you are managing this presently