### PR TITLE
Tatar Translation Fix.

### DIFF
--- a/src/main/resources/assets/antighost/lang/tt_ru.json
+++ b/src/main/resources/assets/antighost/lang/tt_ru.json
@@ -1,6 +1,6 @@
 {
+  "modmenu.summaryTranslation.antighost": "Сезне ялган блоклардан чыгарга ярдәм итүче мод.",
   "modmenu.descriptionTranslation.antighost": "Сезне ялган блоклардан чыгарга ярдәм итүче мод. Блоклар яңартуын сорауны җиберү өчен «/ghost» боерыгын кулланыгыз яки «g» төймәсенә (яңадан билгеләргә мөмкин) басыгыз",
-  "modmenu.descriptionTranslation.antighost": "Сезне ялган блоклардан чыгарга ярдәм итүче мод.".
   "key.categories.antighost": "AntiGhost",
   "key.antighost.reveal": "Үз тирәсендә блокларны яңарту",
   "msg.request": "§9Блоклар яңартуын сорау җиберелде."


### PR DESCRIPTION
- Fixed locale file, so it will become working (in previous PR was syntax mistake that made locale unavailable for Minecraft),