### PR TITLE
Allow servers to control the mod

### DIFF
--- a/src/main/java/de/guntram/mcmod/antighost/AGMode.java
+++ b/src/main/java/de/guntram/mcmod/antighost/AGMode.java
@@ -1,0 +1,22 @@
+package de.guntram.mcmod.antighost;
+
+/**
+ * AntiGhost current mode.
+ *
+ * @author VidTu
+ */
+public enum AGMode {
+    /**
+     * The mod is enabled.
+     * Default state.
+     */
+    ENABLED,
+    /**
+     * The mod is disabled.
+     */
+    DISABLED,
+    /**
+     * The mod is enabled, but will use custom packets for requesting blocks.
+     */
+    CUSTOM;
+}

--- a/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
+++ b/src/main/java/de/guntram/mcmod/antighost/AntiGhost.java
@@ -1,25 +1,33 @@
 package de.guntram.mcmod.antighost;
 
 import de.guntram.mcmod.crowdintranslate.CrowdinTranslate;
+import io.netty.buffer.Unpooled;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_G;
 
 public class AntiGhost implements ClientModInitializer
 {
+    private static final Identifier CHANNEL = new Identifier("antighost", "v1");
     static final String MODID="antighost";
     static KeyBinding requestBlocks;
+    static AGMode mode;
     
     @Override
     public void onInitializeClient()
@@ -37,6 +45,11 @@ public class AntiGhost implements ClientModInitializer
                 })
             );
         });
+        ClientPlayNetworking.registerGlobalReceiver(CHANNEL, (client, handler, buf, responseSender) -> {
+            mode = buf.readEnumConstant(AGMode.class);
+        });
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> mode = AGMode.ENABLED);
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> mode = AGMode.ENABLED);
     }
 
     public void keyPressed() {
@@ -46,22 +59,37 @@ public class AntiGhost implements ClientModInitializer
             player.sendMessage(Text.translatable("msg.request"), false);
         }
     }
-    
+
     public void execute() {
-        MinecraftClient mc=MinecraftClient.getInstance();
+        MinecraftClient mc = MinecraftClient.getInstance();
         ClientPlayNetworkHandler conn = mc.getNetworkHandler();
-        if (conn==null)
+        if (conn == null || mc.player == null) {
             return;
-        BlockPos pos=mc.player.getBlockPos();
-        for (int dx=-4; dx<=4; dx++)
-            for (int dy=-4; dy<=4; dy++)
-                for (int dz=-4; dz<=4; dz++) {
-                    PlayerActionC2SPacket packet=new PlayerActionC2SPacket(
-                            PlayerActionC2SPacket.Action.ABORT_DESTROY_BLOCK, 
-                            new BlockPos(pos.getX()+dx, pos.getY()+dy, pos.getZ()+dz),
-                            Direction.UP       // with ABORT_DESTROY_BLOCK, this value is unused
-                    );
-                    conn.sendPacket(packet);
+        }
+        switch (mode) {
+            case ENABLED -> {
+                BlockPos pos = mc.player.getBlockPos();
+                for (int dx = -4; dx <= 4; dx++) {
+                    for (int dy = -4; dy <= 4; dy++) {
+                        for (int dz = -4; dz <= 4; dz++) {
+                            PlayerActionC2SPacket packet = new PlayerActionC2SPacket(
+                                    PlayerActionC2SPacket.Action.ABORT_DESTROY_BLOCK,
+                                    new BlockPos(pos.getX() + dx, pos.getY() + dy, pos.getZ() + dz),
+                                    Direction.UP       // with ABORT_DESTROY_BLOCK, this value is unused
+                            );
+                            conn.sendPacket(packet);
+                        }
+                    }
                 }
+            }
+            case CUSTOM -> {
+                // Send a custom packet
+                conn.sendPacket(new CustomPayloadC2SPacket(CHANNEL, new PacketByteBuf(Unpooled.EMPTY_BUFFER)));
+            }
+            case DISABLED -> {
+                // Do nothing
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Some servers do have anti cheats or packet limiters
Some admins just want to restrict using mods like this (which can cause problems with player moderation)
To achieve this, I've made a way for servers to block this mod or handle ghost blocks at their behalf.
That being said, the server can select the mode:
- Enabled (default): Like it used to be, using C2S destroy packets.
- Disabled: Fully disable the mod.
- Custom: Send a custom payload on key press, let the server decide how to resync blocks.